### PR TITLE
Changed the position of the titles to center.

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
       <span class="dot" onclick="currentSlide(2)"></span>
     </div>
 
-    <h1 style="font-size: 30px; text-align: center">Introduction to GitHub:</h1>
+    <h1 style="font-size: 30px; text-align: center">Introduction to GitHub:</h1><!--shifted the position of the title to center  -->
     <iframe
       width="560"
       height="315"
@@ -414,7 +414,7 @@
       allowfullscreen>
     </iframe>
     <br />
-    <h1 style="font-size: 30px; text-align: center">Events:</h1>
+    <h1 style="font-size: 30px; text-align: center">Events:</h1><!-- shifted the position of "events" to center -->
 
     <div class="events">
       <h2>Hacktoberfest</h2>

--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
       <span class="dot" onclick="currentSlide(2)"></span>
     </div>
 
-    <h1 style="font-size: 30px; text-align: left">Introduction to GitHub:</h1>
+    <h1 style="font-size: 30px; text-align: center">Introduction to GitHub:</h1>
     <iframe
       width="560"
       height="315"
@@ -414,7 +414,7 @@
       allowfullscreen>
     </iframe>
     <br />
-    <h1 style="font-size: 30px; text-align: left">Events:</h1>
+    <h1 style="font-size: 30px; text-align: center">Events:</h1>
 
     <div class="events">
       <h2>Hacktoberfest</h2>


### PR DESCRIPTION
The titles "introduction to github " and "events" position was changed from the left most part of the page to the center

# For Issue: #44 

## Fixes:
- #44 

## Additions:
- 

# Checklist
- [x] Ensured there is an open issue for your PR
- [x] Added comments to additions
- [x] Followed common formatting conventions for the contribution language
- [x] Tested code to ensure original features are working

Select one:
- [x] Ensured you are the contributer assigned to the Issue for this PR
- [x] Commented for ownership of an OPEN issue where no one is assigned or has yet asked to be assigned

# Screenshots
